### PR TITLE
Add Maven and Gradle support for CodeArtifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,9 @@ Use `aws_access_key_id` and `aws_secret_access_key` for traditional authenticati
 | `ecr_logged_in` | `true` if ECR login was performed, `false` otherwise |
 | `kubectl_context` | Kubernetes context name (if EKS configured) |
 | `codeartifact_logged_in` | `true` if CodeArtifact login was performed, `false` otherwise |
-| `codeartifact_token` | CodeArtifact authorization token (only set for maven/gradle) |
 | `codeartifact_endpoint` | CodeArtifact repository endpoint URL (only set for maven/gradle) |
+
+**Note:** For Maven/Gradle, the authorization token is available via the `CODEARTIFACT_AUTH_TOKEN` environment variable (not exposed as an output for security).
 
 ## ECR Parameters Explained
 
@@ -365,6 +366,19 @@ For cross-account CodeArtifact access, specify the `codeartifact_domain_owner` p
   </activeProfiles>
 </settings>
 ```
+
+**For publishing packages, add to your `pom.xml`:**
+
+```xml
+<distributionManagement>
+  <repository>
+    <id>codeartifact</id>
+    <url>${env.CODEARTIFACT_REPO_URL}</url>
+  </repository>
+</distributionManagement>
+```
+
+**Important:** The `<id>` in `distributionManagement` must match the `<server><id>` in `settings.xml` for authentication to work.
 
 Alternatively, you can create the settings.xml in your workflow:
 

--- a/action.yml
+++ b/action.yml
@@ -97,10 +97,6 @@ outputs:
     description: 'Whether CodeArtifact login was successful'
     value: ${{ steps.codeartifact-status.outputs.logged_in }}
 
-  codeartifact_token:
-    description: 'CodeArtifact authorization token (only set for maven/gradle)'
-    value: ${{ steps.codeartifact-maven-gradle.outputs.token }}
-
   codeartifact_endpoint:
     description: 'CodeArtifact repository endpoint URL (only set for maven/gradle)'
     value: ${{ steps.codeartifact-maven-gradle.outputs.endpoint }}
@@ -183,6 +179,20 @@ runs:
         echo "📍 Context: $CONTEXT"
         echo "::endgroup::"
 
+    - name: Validate CodeArtifact tool
+      if: inputs.codeartifact_domain != '' && inputs.codeartifact_repository != '' && inputs.codeartifact_tool != ''
+      shell: bash
+      run: |
+        case "${{ inputs.codeartifact_tool }}" in
+          npm|pip|twine|dotnet|nuget|swift|maven|gradle)
+            # Valid tool
+            ;;
+          *)
+            echo "::error::Unsupported codeartifact_tool: '${{ inputs.codeartifact_tool }}'. Supported tools: npm, pip, twine, dotnet, nuget, swift, maven, gradle"
+            exit 1
+            ;;
+        esac
+
     - name: Login to AWS CodeArtifact (npm, pip, twine, etc.)
       id: codeartifact
       if: inputs.codeartifact_domain != '' && inputs.codeartifact_repository != '' && inputs.codeartifact_tool != '' && inputs.codeartifact_tool != 'maven' && inputs.codeartifact_tool != 'gradle'
@@ -203,12 +213,12 @@ runs:
 
         # Login to CodeArtifact
         aws codeartifact login \
-          --tool ${{ inputs.codeartifact_tool }} \
-          --domain ${{ inputs.codeartifact_domain }} \
-          --domain-owner $CA_DOMAIN_OWNER \
-          --repository ${{ inputs.codeartifact_repository }} \
-          --region $CA_REGION \
-          --duration-seconds ${{ inputs.codeartifact_duration }}
+          --tool "${{ inputs.codeartifact_tool }}" \
+          --domain "${{ inputs.codeartifact_domain }}" \
+          --domain-owner "$CA_DOMAIN_OWNER" \
+          --repository "${{ inputs.codeartifact_repository }}" \
+          --region "$CA_REGION" \
+          --duration-seconds "${{ inputs.codeartifact_duration }}"
 
         echo "✅ CodeArtifact login successful"
         echo "📦 Domain: ${{ inputs.codeartifact_domain }}"
@@ -236,13 +246,13 @@ runs:
 
         # Get CodeArtifact authorization token
         echo "Fetching CodeArtifact authorization token..."
-        CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token \
-          --domain ${{ inputs.codeartifact_domain }} \
-          --domain-owner $CA_DOMAIN_OWNER \
-          --region $CA_REGION \
-          --duration-seconds ${{ inputs.codeartifact_duration }} \
+        CODEARTIFACT_AUTH_TOKEN="$(aws codeartifact get-authorization-token \
+          --domain "${{ inputs.codeartifact_domain }}" \
+          --domain-owner "$CA_DOMAIN_OWNER" \
+          --region "$CA_REGION" \
+          --duration-seconds "${{ inputs.codeartifact_duration }}" \
           --query authorizationToken \
-          --output text)
+          --output text)"
 
         # Mask the token in logs
         echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
@@ -250,19 +260,16 @@ runs:
         # Export token as environment variable
         echo "CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN" >> $GITHUB_ENV
 
-        # Set as output (masked)
-        echo "token=$CODEARTIFACT_AUTH_TOKEN" >> $GITHUB_OUTPUT
-
         # Get repository endpoint URL
         echo "Fetching CodeArtifact repository endpoint..."
-        CODEARTIFACT_REPO_URL=$(aws codeartifact get-repository-endpoint \
-          --domain ${{ inputs.codeartifact_domain }} \
-          --domain-owner $CA_DOMAIN_OWNER \
-          --repository ${{ inputs.codeartifact_repository }} \
+        CODEARTIFACT_REPO_URL="$(aws codeartifact get-repository-endpoint \
+          --domain "${{ inputs.codeartifact_domain }}" \
+          --domain-owner "$CA_DOMAIN_OWNER" \
+          --repository "${{ inputs.codeartifact_repository }}" \
           --format maven \
-          --region $CA_REGION \
+          --region "$CA_REGION" \
           --query repositoryEndpoint \
-          --output text)
+          --output text)"
 
         # Export endpoint as environment variable
         echo "CODEARTIFACT_REPO_URL=$CODEARTIFACT_REPO_URL" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ inputs:
     required: false
 
   codeartifact_tool:
-    description: 'Tool to configure for CodeArtifact (npm, pip, twine, dotnet, nuget, swift)'
+    description: 'Tool to configure for CodeArtifact (npm, pip, twine, dotnet, nuget, swift, maven, gradle)'
     required: false
 
   codeartifact_region:
@@ -96,6 +96,14 @@ outputs:
   codeartifact_logged_in:
     description: 'Whether CodeArtifact login was successful'
     value: ${{ steps.codeartifact-status.outputs.logged_in }}
+
+  codeartifact_token:
+    description: 'CodeArtifact authorization token (only set for maven/gradle)'
+    value: ${{ steps.codeartifact-maven-gradle.outputs.token }}
+
+  codeartifact_endpoint:
+    description: 'CodeArtifact repository endpoint URL (only set for maven/gradle)'
+    value: ${{ steps.codeartifact-maven-gradle.outputs.endpoint }}
 
 runs:
   using: 'composite'
@@ -175,9 +183,9 @@ runs:
         echo "📍 Context: $CONTEXT"
         echo "::endgroup::"
 
-    - name: Login to AWS CodeArtifact
+    - name: Login to AWS CodeArtifact (npm, pip, twine, etc.)
       id: codeartifact
-      if: inputs.codeartifact_domain != '' && inputs.codeartifact_repository != '' && inputs.codeartifact_tool != ''
+      if: inputs.codeartifact_domain != '' && inputs.codeartifact_repository != '' && inputs.codeartifact_tool != '' && inputs.codeartifact_tool != 'maven' && inputs.codeartifact_tool != 'gradle'
       shell: bash
       run: |
         echo "::group::CodeArtifact Configuration"
@@ -208,12 +216,90 @@ runs:
         echo "🔧 Tool: ${{ inputs.codeartifact_tool }}"
         echo "::endgroup::"
 
+    - name: Setup AWS CodeArtifact for Maven/Gradle
+      id: codeartifact-maven-gradle
+      if: inputs.codeartifact_domain != '' && inputs.codeartifact_repository != '' && (inputs.codeartifact_tool == 'maven' || inputs.codeartifact_tool == 'gradle')
+      shell: bash
+      run: |
+        echo "::group::CodeArtifact Configuration for ${{ inputs.codeartifact_tool }}"
+
+        # Set defaults
+        CA_REGION="${{ inputs.codeartifact_region }}"
+        if [[ -z "$CA_REGION" ]]; then
+          CA_REGION="${{ inputs.aws_region }}"
+        fi
+
+        CA_DOMAIN_OWNER="${{ inputs.codeartifact_domain_owner }}"
+        if [[ -z "$CA_DOMAIN_OWNER" ]]; then
+          CA_DOMAIN_OWNER="${{ steps.aws.outputs.aws-account-id }}"
+        fi
+
+        # Get CodeArtifact authorization token
+        echo "Fetching CodeArtifact authorization token..."
+        CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token \
+          --domain ${{ inputs.codeartifact_domain }} \
+          --domain-owner $CA_DOMAIN_OWNER \
+          --region $CA_REGION \
+          --duration-seconds ${{ inputs.codeartifact_duration }} \
+          --query authorizationToken \
+          --output text)
+
+        # Mask the token in logs
+        echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
+
+        # Export token as environment variable
+        echo "CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN" >> $GITHUB_ENV
+
+        # Set as output (masked)
+        echo "token=$CODEARTIFACT_AUTH_TOKEN" >> $GITHUB_OUTPUT
+
+        # Get repository endpoint URL
+        echo "Fetching CodeArtifact repository endpoint..."
+        CODEARTIFACT_REPO_URL=$(aws codeartifact get-repository-endpoint \
+          --domain ${{ inputs.codeartifact_domain }} \
+          --domain-owner $CA_DOMAIN_OWNER \
+          --repository ${{ inputs.codeartifact_repository }} \
+          --format maven \
+          --region $CA_REGION \
+          --query repositoryEndpoint \
+          --output text)
+
+        # Export endpoint as environment variable
+        echo "CODEARTIFACT_REPO_URL=$CODEARTIFACT_REPO_URL" >> $GITHUB_ENV
+
+        # Set as output
+        echo "endpoint=$CODEARTIFACT_REPO_URL" >> $GITHUB_OUTPUT
+
+        echo "✅ CodeArtifact token and endpoint configured"
+        echo "📦 Domain: ${{ inputs.codeartifact_domain }}"
+        echo "📦 Repository: ${{ inputs.codeartifact_repository }}"
+        echo "🔧 Tool: ${{ inputs.codeartifact_tool }}"
+        echo "🔗 Endpoint: $CODEARTIFACT_REPO_URL"
+        echo ""
+        echo "💡 Environment variables set:"
+        echo "   - CODEARTIFACT_AUTH_TOKEN (masked)"
+        echo "   - CODEARTIFACT_REPO_URL"
+        echo ""
+        echo "📝 Next steps:"
+        if [[ "${{ inputs.codeartifact_tool }}" == "maven" ]]; then
+          echo "   Configure your settings.xml to use \${env.CODEARTIFACT_AUTH_TOKEN}"
+          echo "   and \${env.CODEARTIFACT_REPO_URL}"
+        else
+          echo "   Configure your build.gradle to use System.env.CODEARTIFACT_AUTH_TOKEN"
+          echo "   and System.env.CODEARTIFACT_REPO_URL"
+        fi
+        echo "::endgroup::"
+
     - name: Log CodeArtifact status
       id: codeartifact-status
       if: inputs.codeartifact_domain != '' && inputs.codeartifact_repository != '' && inputs.codeartifact_tool != ''
       shell: bash
       run: |
-        echo "::notice::📦 CodeArtifact login successful for ${{ inputs.codeartifact_tool }}"
+        if [[ "${{ inputs.codeartifact_tool }}" == "maven" ]] || [[ "${{ inputs.codeartifact_tool }}" == "gradle" ]]; then
+          echo "::notice::📦 CodeArtifact token configured for ${{ inputs.codeartifact_tool }}"
+        else
+          echo "::notice::📦 CodeArtifact login successful for ${{ inputs.codeartifact_tool }}"
+        fi
         echo "logged_in=true" >> $GITHUB_OUTPUT
 
     - name: Set CodeArtifact not logged in


### PR DESCRIPTION
## Summary

Adds support for Maven and Gradle authentication with AWS CodeArtifact. Since the AWS CLI `codeartifact login` command doesn't support Maven/Gradle, this implements token-based authentication by exporting environment variables.

## Changes

- **Token-based authentication**: Exports `CODEARTIFACT_AUTH_TOKEN` and `CODEARTIFACT_REPO_URL` as environment variables for Maven/Gradle
- **Security**: Token is properly masked and only available via environment variable (not exposed as output)
- **Input validation**: Early validation of `codeartifact_tool` with clear error messages
- **Shell hardening**: Quoted all variable expansions for safety
- **New output**: Added `codeartifact_endpoint` output for convenience
- **Documentation**: Comprehensive examples for both Maven (`settings.xml`, `pom.xml`) and Gradle (`build.gradle`, `build.gradle.kts`)

## Usage

```yaml
- uses: KoalaOps/login-aws@v1
  with:
    role_to_assume: ${{ secrets.AWS_ROLE_ARN }}
    aws_region: us-east-1
    codeartifact_domain: my-artifacts
    codeartifact_repository: maven-repo
    codeartifact_tool: maven  # or gradle
```

Users configure their build tools to reference the exported environment variables (see README for full examples).