### PR TITLE
feat: add CodeArtifact namespace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Use `aws_access_key_id` and `aws_secret_access_key` for traditional authenticati
 | `codeartifact_region` | CodeArtifact region (defaults to `aws_region`) | ❌ | - |
 | `codeartifact_domain_owner` | AWS account ID that owns the domain (defaults to authenticated account) | ❌ | - |
 | `codeartifact_duration` | Token duration in seconds | ❌ | `43200` (12 hours) |
+| `codeartifact_namespace` | CodeArtifact namespace for the repository | ❌ | - |
 | `codeartifact_output_token` | Output token as env vars instead of auto-login (useful for Docker builds) | ❌ | `false` |
 
 *Either use OIDC (`role_to_assume`) or access keys (`aws_access_key_id` + `aws_secret_access_key`)
@@ -190,6 +191,7 @@ To enable CodeArtifact login, you must provide:
 - `codeartifact_region` - Defaults to the main `aws_region` input
 - `codeartifact_domain_owner` - Defaults to the authenticated AWS account
 - `codeartifact_duration` - Token lifetime in seconds (default: 43200 = 12 hours)
+- `codeartifact_namespace` - Namespace for the repository (e.g., `com.mycompany` for Maven, `my-org` for npm)
 
 ### Cross-Account Access
 For cross-account CodeArtifact access, specify the `codeartifact_domain_owner` parameter with the AWS account ID that owns the domain.
@@ -290,6 +292,7 @@ For cross-account CodeArtifact access, specify the `codeartifact_domain_owner` p
     codeartifact_domain: my-artifacts
     codeartifact_repository: npm-store
     codeartifact_tool: npm
+    codeartifact_namespace: my-org  # Optional: specify namespace
 
 - name: Install dependencies
   run: npm install
@@ -309,6 +312,7 @@ For cross-account CodeArtifact access, specify the `codeartifact_domain_owner` p
     codeartifact_domain: my-artifacts
     codeartifact_repository: pypi-store
     codeartifact_tool: pip
+    codeartifact_namespace: my-org  # Optional: specify namespace
 
 - name: Install dependencies
   run: pip install -r requirements.txt
@@ -331,6 +335,7 @@ For cross-account CodeArtifact access, specify the `codeartifact_domain_owner` p
     codeartifact_domain_owner: "123456789012"  # Different account
     codeartifact_repository: npm-shared
     codeartifact_tool: npm
+    codeartifact_namespace: shared-org  # Optional: specify namespace
     codeartifact_duration: 43200  # 12 hours
 ```
 
@@ -345,6 +350,7 @@ For cross-account CodeArtifact access, specify the `codeartifact_domain_owner` p
     codeartifact_domain: my-artifacts
     codeartifact_repository: maven-repo
     codeartifact_tool: maven
+    codeartifact_namespace: com.mycompany  # Optional: specify namespace
 
 - name: Build with Maven
   run: mvn clean install
@@ -452,6 +458,7 @@ Alternatively, you can create the settings.xml in your workflow:
     codeartifact_domain: my-artifacts
     codeartifact_repository: maven-repo
     codeartifact_tool: gradle
+    codeartifact_namespace: com.mycompany  # Optional: specify namespace
 
 - name: Build with Gradle
   run: ./gradlew build
@@ -474,6 +481,7 @@ When building Docker images that need to install packages from CodeArtifact, you
     codeartifact_domain: my-artifacts
     codeartifact_repository: npm-store
     codeartifact_tool: npm
+    codeartifact_namespace: my-org  # Optional: specify namespace
     codeartifact_output_token: 'true'  # Enable token mode
     enable_ecr_login: true
 

--- a/action.yml
+++ b/action.yml
@@ -76,6 +76,10 @@ inputs:
     required: false
     default: '43200'
 
+  codeartifact_namespace:
+    description: 'CodeArtifact namespace for the repository'
+    required: false
+
   codeartifact_output_token:
     description: 'Output the CodeArtifact token instead of using aws codeartifact login (useful for custom configurations)'
     required: false
@@ -223,12 +227,16 @@ runs:
           --domain-owner "$CA_DOMAIN_OWNER" \
           --repository "${{ inputs.codeartifact_repository }}" \
           --region "$CA_REGION" \
-          --duration-seconds "${{ inputs.codeartifact_duration }}"
+          --duration-seconds "${{ inputs.codeartifact_duration }}" \
+          ${{ inputs.codeartifact_namespace != '' && format('--namespace {0}', inputs.codeartifact_namespace) || '' }}
 
         echo "✅ CodeArtifact login successful"
         echo "📦 Domain: ${{ inputs.codeartifact_domain }}"
         echo "📦 Repository: ${{ inputs.codeartifact_repository }}"
         echo "🔧 Tool: ${{ inputs.codeartifact_tool }}"
+        if [[ -n "${{ inputs.codeartifact_namespace }}" ]]; then
+          echo "🏷️  Namespace: ${{ inputs.codeartifact_namespace }}"
+        fi
         echo "::endgroup::"
 
     - name: Setup AWS CodeArtifact Token Mode
@@ -336,6 +344,9 @@ runs:
         echo "📦 Domain: ${{ inputs.codeartifact_domain }}"
         echo "📦 Repository: ${{ inputs.codeartifact_repository }}"
         echo "🔧 Tool: ${{ inputs.codeartifact_tool }}"
+        if [[ -n "${{ inputs.codeartifact_namespace }}" ]]; then
+          echo "🏷️  Namespace: ${{ inputs.codeartifact_namespace }}"
+        fi
         echo "🔗 Endpoint: $CODEARTIFACT_REPO_URL"
         echo ""
         echo "💡 Environment variables set:"
@@ -414,5 +425,9 @@ runs:
         fi
 
         if [[ -n "${{ inputs.codeartifact_domain }}" ]] && [[ -n "${{ inputs.codeartifact_repository }}" ]] && [[ -n "${{ inputs.codeartifact_tool }}" ]]; then
-          echo "| **CodeArtifact** | ✅ Configured | Domain: ${{ inputs.codeartifact_domain }}, Repo: ${{ inputs.codeartifact_repository }}, Tool: ${{ inputs.codeartifact_tool }} |" >> $GITHUB_STEP_SUMMARY
+          NAMESPACE_INFO=""
+          if [[ -n "${{ inputs.codeartifact_namespace }}" ]]; then
+            NAMESPACE_INFO=", Namespace: ${{ inputs.codeartifact_namespace }}"
+          fi
+          echo "| **CodeArtifact** | ✅ Configured | Domain: ${{ inputs.codeartifact_domain }}, Repo: ${{ inputs.codeartifact_repository }}, Tool: ${{ inputs.codeartifact_tool }}$NAMESPACE_INFO |" >> $GITHUB_STEP_SUMMARY
         fi


### PR DESCRIPTION
## Summary
This PR adds support for the `--namespace` parameter in AWS CodeArtifact authentication, allowing users to specify repository namespaces for different package managers.

## Changes Made
- ✅ Added `codeartifact_namespace` input parameter (optional)
- ✅ Updated `aws codeartifact login` command to include `--namespace` when provided
- ✅ Fixed token-based authentication (removed invalid `--namespace` from `get-authorization-token`)
- ✅ Updated documentation with namespace examples for all package managers
- ✅ Fixed namespace format documentation (removed `@` symbol from examples)
- ✅ Enhanced logging to display namespace in success messages and summary table

## Backward Compatibility
This change is fully backward compatible - existing workflows will continue to work without any modifications.

## Testing
- [x] Verified `--namespace` parameter is correctly added to `aws codeartifact login` command
- [x] Verified `--namespace` parameter is NOT added to `get-authorization-token` command (not supported)
- [x] Updated all documentation examples with proper namespace formats

## Examples
```yaml
# NPM with namespace
- uses: KoalaOps/login-aws@v1
  with:
    codeartifact_domain: my-artifacts
    codeartifact_repository: npm-store
    codeartifact_tool: npm
    codeartifact_namespace: my-org  # Just the scope name, no @

# Maven with namespace  
- uses: KoalaOps/login-aws@v1
  with:
    codeartifact_domain: my-artifacts
    codeartifact_repository: maven-repo
    codeartifact_tool: maven
    codeartifact_namespace: com.mycompany  # Maven groupId
```

## References
- [AWS CodeArtifact Login Command Documentation](https://docs.aws.amazon.com/cli/latest/reference/codeartifact/login.html)
- [AWS CodeArtifact Namespace Concepts](https://docs.aws.amazon.com/codeartifact/latest/ug/codeartifact-concepts.html)